### PR TITLE
Add PHP-8.1 test and illuminate/http ^8 & ^9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         php:
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "homepage": "https://github.com/PHPWatch/Laravel-Fast404",
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.4",
-        "illuminate/http": "^5.5 || ^6.0 || ^7.0"
+        "php": "^7.4 || ^8.0",
+        "illuminate/http": "^5.5 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.1"


### PR DESCRIPTION
# Changed log

- Adding the `PHP-8.1` version test during the GitHub workflow running.
- Adding the `^8.0` PHP version requirement for this PHP package.
- Adding the `^8.0` and `^9.0` version definition for the `illuminate/http` dependency package.